### PR TITLE
Move namespace no.ssb.barn -> no.ssb.barnevern

### DIFF
--- a/no.ssb.barnevern.fagsystem/no.ssb.barnevern.fagsystem.v1.innrapportering.json
+++ b/no.ssb.barnevern.fagsystem/no.ssb.barnevern.fagsystem.v1.innrapportering.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://barn.ssb.no/document-incoming-xml.schema.json",
+  "$id": "https://barnevern.ssb.no/document-incoming-xml.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "DocumentReceivedMessage",
   "description": "XML payload with XSD-version",

--- a/no.ssb.barnevern.fagsystem/no.ssb.barnevern.fagsystem.v1.valideringsrapport.json
+++ b/no.ssb.barnevern.fagsystem/no.ssb.barnevern.fagsystem.v1.valideringsrapport.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://barn.ssb.no/validation-report.schema.json",
+  "$id": "https://barnevern.ssb.no/validation-report.schema.json",
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ValidationReport",
   "description": "Validation report for validated XML payload",


### PR DESCRIPTION
Communicates more clearly which domain the schemas are for